### PR TITLE
Add credit subscriber

### DIFF
--- a/src/layerzero/token/oft/interfaces/IOFTSubscriber.sol
+++ b/src/layerzero/token/oft/interfaces/IOFTSubscriber.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.5.0;
+
+/**
+ * @dev Interface of the OFT subscriber
+ */
+interface IOFTSubscriber {
+    /**
+     * @notice Notifies the contract about a token credit from a source chain.
+     * @dev This function allows external systems to inform the contract about credited tokens.
+     * @param srcChainId Chain ID of the source chain.
+     * @param token Address of the credited token.
+     * @param src Address of the sender on the source chain.
+     * @param amount Amount of tokens credited.
+     */
+    function notifyCredit(uint16 srcChainId, address token, address src, uint256 amount) external;
+}

--- a/src/layerzero/token/oft/v1/OFTCoreUpgradeable.sol
+++ b/src/layerzero/token/oft/v1/OFTCoreUpgradeable.sol
@@ -8,6 +8,8 @@ import {BytesLib} from "@layerzerolabs/contracts/libraries/BytesLib.sol";
 
 import {NonblockingLzAppUpgradeable} from "../../../lzApp/NonblockingLzAppUpgradeable.sol";
 
+import {IOFTSubscriber} from "../interfaces/IOFTSubscriber.sol";
+
 /**
  * @title OFTCoreUpgradeable
  * @dev This contract extends NonblockingLzAppUpgradeable to provide a core implementation for OFT (On-Chain Forwarding
@@ -202,14 +204,20 @@ abstract contract OFTCoreUpgradeable is NonblockingLzAppUpgradeable, ERC165, IOF
      * This function is called internally when a PT_SEND packet type is received.
      *
      * @param srcChainId The ID of the source chain from which the tokens were sent.
+     * @param srcAddressBytes The address on the source chain from which the message originated.
      * @param payload The payload containing the details of the sent tokens.
      */
-    function _sendAck(uint16 srcChainId, bytes memory, uint64, bytes memory payload) internal virtual {
+    function _sendAck(uint16 srcChainId, bytes memory srcAddressBytes, uint64, bytes memory payload) internal virtual {
         (, bytes memory toAddressBytes, uint256 amount) = abi.decode(payload, (uint16, bytes, uint256));
 
+        address src = srcAddressBytes.toAddress(0);
         address to = toAddressBytes.toAddress(0);
 
         amount = _creditTo(srcChainId, to, amount);
+
+        //send the acknowledgement to the reciever for the amount credited from the source chain
+        try IOFTSubscriber(to).notifyCredit(srcChainId, address(this), src, amount) {} catch {}
+
         emit ReceiveFromChain(srcChainId, to, amount);
     }
 

--- a/src/layerzero/token/oft/v1/OFTCoreUpgradeable.sol
+++ b/src/layerzero/token/oft/v1/OFTCoreUpgradeable.sol
@@ -215,7 +215,7 @@ abstract contract OFTCoreUpgradeable is NonblockingLzAppUpgradeable, ERC165, IOF
 
         amount = _creditTo(srcChainId, to, amount);
 
-        //send the acknowledgement to the reciever for the amount credited from the source chain
+        // send the acknowledgement to the receiver for the amount credited from the source chain
         try IOFTSubscriber(to).notifyCredit(srcChainId, address(this), src, amount) {} catch {}
 
         emit ReceiveFromChain(srcChainId, to, amount);


### PR DESCRIPTION
Notifies the receiver about the credited amount and sender address from the source chain during the acknowledgment process.